### PR TITLE
Fix the tabs content so it wraps on smaller screens

### DIFF
--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -232,7 +232,7 @@ export default function Sidebar({
                 </CardHeader>
                 <CardContent>
                   <Tabs defaultValue="commercial">
-                    <TabsList>
+                    <TabsList className="flex flex-wrap">
                       {(activeElement?.dnsConfiguration?.commercial?.subresourceNames?.length ?? 0) > 0 && (
                         <TabsTrigger value="commercial">Commercial</TabsTrigger>
                       )}

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -2,7 +2,6 @@
 
 import * as React from "react"
 import * as TabsPrimitive from "@radix-ui/react-tabs"
-
 import { cn } from "@/lib/utils"
 
 const Tabs = TabsPrimitive.Root
@@ -14,7 +13,7 @@ const TabsList = React.forwardRef<
   <TabsPrimitive.List
     ref={ref}
     className={cn(
-      "inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground",
+      "flex-wrap h-fit w-fit justify-center rounded-md bg-muted p-1 text-muted-foreground",
       className
     )}
     {...props}
@@ -44,7 +43,7 @@ const TabsContent = React.forwardRef<
   <TabsPrimitive.Content
     ref={ref}
     className={cn(
-      "ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+      "ring-offset-background focus-visible:outline-none",
       className
     )}
     {...props}


### PR DESCRIPTION
This PR fixes some bugs where there was a focus area showing up around TabContent and TabsList was not wrapping on smaller devices.