### PR TITLE
Added Cloud Shell Button

### DIFF
--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -222,6 +222,18 @@ export default function Sidebar({
                       <span>{isMobile ? 'Portal' : 'Azure Portal'}</span>
                     </a>
                   )}
+                  {activeElement?.portalUrl && (
+                    <a
+                      target="_blank"
+                      href={`https://shell.azure.com/?cloudshell=true}`}
+                      className="flex justify-start items-center text-sm break-all border p-2 rounded-lg border-gray-500 hover:border-gray-200 transition-all mr-4 mb-2"
+                    >
+                      <div className="mr-2">
+                        <Icons.Azure width={24} height={24} />
+                      </div>
+                      <span>{isMobile ? 'Shell' : 'Cloud Shell'}</span>
+                    </a>
+                  )}
                 </div>
               </CardContent>
             </Card>


### PR DESCRIPTION
Added a button to open cloud shell. Initial testing and research is indicating that security features prevent loading scripts into the cloud shell via button injection. Having the ability to copy from the sidebar may be a good alternative. 